### PR TITLE
A big number of improvements

### DIFF
--- a/say_it_again.lua
+++ b/say_it_again.lua
@@ -54,13 +54,12 @@ Abbreviations used in code:
 --[[  Settings  ]]--
 local sia_settings =
 {
-    --charset = "iso-8859-1", -- works for english and french subtitles (try also "Windows-1252")
-    charset = nil,          -- UT8 encoding
-    dict_dir = "c:/!MY_DOCS/say_it_again/dict",            -- where Stardict dictionaries are located
-    wordnet_dir = "c:/!MY_DOCS/say_it_again/WordNet", -- where WordNet files are located
-    --chosen_dict = "c:/!MY_DOCS/say_it_again/dict/Oxford Advanced Learner's Dictionary", -- Stardict dictionary used by default (there should be 3 files with this name but different extensions)
-    chosen_dict = "c:/!MY_DOCS/say_it_again/dict/OxfordAmericanDictionaryEnEn", -- Stardict dictionary used by default (there should be 3 files with this name but different extensions)
-    words_file_path = "c:/!MY_DOCS/say_it_again/sia_words.txt", -- if 'nil' then "Desktop/sia_words.txt" will be used
+    charset = "iso-8859-1",          -- works for english and french subtitles (try also "Windows-1252")
+    --charset = nil,                 -- UTF8 encoding
+    dict_dir = "C:/dict",            -- where Stardict dictionaries are located
+    wordnet_dir = "C:/dict/wordnet", -- where WordNet files are located
+    chosen_dict = "C:/dict/OxfordAmericanDictionaryEnEn", -- Stardict dictionary used by default (there should be 3 files with this name but different extensions)
+    words_file_path = nil, -- if 'nil' then "Desktop/sia_words.txt" will be used
     always_show_subtitles = false,
     osd_position = "top",
     help_duration = 6, -- sec; change to nil to disable osd help
@@ -74,7 +73,7 @@ local sia_settings =
     key_always_show_subs = 114, -- R
     
     -- global subtitles time shift to compensate vlc audio start delay or lack of subtitles synchronization
-    subs_time_shift = -2.5
+    subs_time_shift = 0
 }
 
 


### PR DESCRIPTION
First of all, whole range of existing features and using patterns have been remained unchanged. This means whole new functionality keeps invisible (almost completely) until user activates it.

**ChangeLog**
- Second language subtitles. File should be named as video_file_2.srt and could be activated with [ctrl+backspace] key. Second language subtitles available in all modes. Script keeps working fine without it.
- First and second subtitles could be shown on screen simultaneously
- Ability to add global time shift for subtitles and audio synchronization
- Ability to add any number previous/next phrases before/after current in Add Word dialog
- [R] key switches "always show subtitles" toggle
- Bug fixed: Sometimes there was subtitles duplication on screen
